### PR TITLE
[composer.json] add vendor name to fix install error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "sendgrid-php-example",
+  "name": "sendgrid/sendgrid-php-example",
   "description": "Example of using the SendGrid php library.",
   "version": "0.0.1",
   "homepage": "http://github.com/scottmotte/sendgrid-php-example",


### PR DESCRIPTION
`composer install` occurs error.

```
  [Composer\Json\JsonValidationException]
  "./composer.json" does not match the expected JSON schema:
   - name : Does not match the regex pattern ^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z
  0-9](([_.]?|-{0,2})[a-z0-9]+)*$
```

This is caused by missing vendor-name on "name" in composer.json, so add the GitHub username(sendgrid) as a vendor-name.